### PR TITLE
[FIX] Prevent data buffer to get larger than INFLUX_MAX_BUF

### DIFF
--- a/main.go
+++ b/main.go
@@ -155,6 +155,15 @@ func (d Database) Finalize() {
 	<-d.done
 }
 
+func (d Database) FinalizeTimeout(timeout time.Duration) {
+	d.shutdown <- struct{}{}
+	select {
+	case <-time.After(timeout):
+		log.Println("Influx finalization timed out")
+	case <-d.done:
+	}
+}
+
 func New(host string, database string) (*Database, error) {
 	return NewRaw(fmt.Sprintf("http://%s:8086/write?db=%s", host, database))
 }

--- a/main.go
+++ b/main.go
@@ -152,8 +152,7 @@ func (d Database) run() {
 }
 
 func (d Database) Finalize() {
-	d.shutdown <- struct{}{}
-	<-d.done
+	d.FinalizeCtx(context.Background())
 }
 
 func (d Database) FinalizeCtx(ctx context.Context) {

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package influx
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -155,10 +156,10 @@ func (d Database) Finalize() {
 	<-d.done
 }
 
-func (d Database) FinalizeTimeout(timeout time.Duration) {
+func (d Database) FinalizeCtx(ctx context.Context) {
 	d.shutdown <- struct{}{}
 	select {
-	case <-time.After(timeout):
+	case <-ctx.Done():
 		log.Println("Influx finalization timed out")
 	case <-d.done:
 	}

--- a/main.go
+++ b/main.go
@@ -115,10 +115,10 @@ func (d Database) run() {
 		select {
 		case _ = <-d.shutdown:
 			close(d.c)
-			shutdown = true
 			for x := range d.c {
 				data = append(data, string(x))
 			}
+			shutdown = true
 		case x := <-inChannel:
 			data = append(data, string(x))
 			if len(data) < INFLUX_MAX_BUF {


### PR DESCRIPTION
When buffer is full, we stop reading from the channel so that callers are aware our buffer is full.

Library only shutdowns after having written all its data.

Also adds a `FinalizeCtx` method to shutdown influx with a context